### PR TITLE
Add importance score

### DIFF
--- a/overlore/types.py
+++ b/overlore/types.py
@@ -5,4 +5,4 @@ from overlore.eternum.types import AttackingEntityIds, RealmPosition, ResourceAm
 EventKeys: TypeAlias = list[str]
 EventData: TypeAlias = list[str]
 ToriiEvent: TypeAlias = dict[str, dict[str, str | EventKeys | EventData]]
-ParsedEvent: TypeAlias = dict[str, int | RealmPosition | ResourceAmounts | AttackingEntityIds]
+ParsedEvent: TypeAlias = dict[str, int | RealmPosition | ResourceAmounts | AttackingEntityIds | float]


### PR DESCRIPTION
Adds importance score to trade events and to combat events: 
- trade takes the total amount of resources traded and assigns a score based on the following linear equation: $(importance = 1/10 * amountOfResources)$
- combat checks if we stole resources or if someone suffered damages (one can't happen if the other is true). 
  -  if damages: $(1/100 * amountOfDamages)$
  - if resources stolen: $(1/10 * amountOfResources)$