### PR TITLE
enh: remove locks and assert threadsafety from sqlite

### DIFF
--- a/overlore/sqlite/db.py
+++ b/overlore/sqlite/db.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 from sqlite3 import Connection
-from threading import Lock
 from typing import Any, Callable
 
 import sqlean
@@ -11,31 +10,24 @@ PreloadFunction = Callable[[Connection], None]
 FunctionCallable = Callable[..., Any | None]
 CustomFunction = tuple[str, int, FunctionCallable]
 
+THREADSAFE = "THREADSAFE=1"
+
 
 class Database:
     db: Connection
-    lock = Lock()
-
-    def _lock(self) -> None:
-        self.lock.acquire(blocking=True, timeout=1000)
-
-    def _release(self) -> None:
-        self.lock.release()
 
     def __init__(self) -> None:
-        raise RuntimeError(f"{self.__class__.__name__}: call instance() instead")
+        raise RuntimeError(f"{self.__class__.__name__}: call _init from child")
 
     def _load_extensions(self, extensions: list[str]) -> None:
         for ext in extensions:
             self.db.load_extension(ext)
 
     def _insert(self, query: str, values: tuple[Any, ...]) -> int:
-        self._lock()
         cursor = self.db.cursor()
         cursor.execute(query, values)
         self.db.commit()
         added_id = cursor.lastrowid if cursor.lastrowid else 0
-        self._release()
         return added_id
 
     def _use_first_boot_queries(self, queries: list[str]) -> None:
@@ -63,7 +55,15 @@ class Database:
         functions: list[CustomFunction],
         preload: PreloadFunction,
     ) -> None:
-        self.db: Connection = sqlean.connect(path)
+        self.db: Connection = sqlean.connect(path, check_same_thread=False)
+        threadsafety = self.db.execute(
+            """
+            select * from pragma_compile_options
+            where compile_options like 'THREADSAFE=%'
+            """
+        ).fetchone()[0]
+        if threadsafety != THREADSAFE:
+            raise SystemError("SQlean is not configured for thread safety")
 
         self.db.enable_load_extension(True)
         preload(self.db)


### PR DESCRIPTION
Given that sqlite is by default configured as thread-safe, we don't need locks anymore