### PR TITLE
backoffable torii connection across a list of subscriptions

### DIFF
--- a/overlore/config.py
+++ b/overlore/config.py
@@ -14,6 +14,10 @@ def setup_logging(log_to_file: Optional[str] = None) -> None:
     # Create a formatter
     formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
+    # Check if handlers already exist for this logger
+    if logger.hasHandlers():
+        logger.handlers.clear()  # Clear existing handlers
+
     handler: Handler
     if log_to_file is not None:
         # Create a file handler and set the level to debug

--- a/overlore/townhall/service.py
+++ b/overlore/townhall/service.py
@@ -10,7 +10,7 @@ from websockets.exceptions import ConnectionClosedError
 
 from overlore.config import Config
 from overlore.graphql.constants import Subscriptions
-from overlore.graphql.event import process_event, torii_boot_sync, torii_event_sub
+from overlore.graphql.event import process_event, torii_boot_sync, torii_subscription_connection
 from overlore.llm.open_ai import OpenAIHandler
 from overlore.sqlite.events_db import EventsDatabase
 from overlore.sqlite.vector_db import VectorDatabase
@@ -52,8 +52,11 @@ async def start() -> None:
     try:
         await asyncio.gather(
             overlore_pulse,
-            torii_event_sub(config.TORII_WS, process_event, Subscriptions.COMBAT_OUTCOME_EVENT_EMITTED),
-            torii_event_sub(config.TORII_WS, process_event, Subscriptions.ORDER_ACCEPTED_EVENT_EMITTED),
+            torii_subscription_connection(
+                config.TORII_WS,
+                process_event,
+                [Subscriptions.COMBAT_OUTCOME_EVENT_EMITTED, Subscriptions.ORDER_ACCEPTED_EVENT_EMITTED],
+            ),
         )
     except ConnectionClosedError:
         logger.warning("Connection close on Torii, need to reconnect here")


### PR DESCRIPTION
refactored following the example listed here:

https://gql.readthedocs.io/en/latest/advanced/async_advanced_usage.html

added logging on each backoff so we can monitor the functionality and tweak if necessary